### PR TITLE
a little proposition for UIAspectRatioConstraint.

### DIFF
--- a/src/CanvasDraw/FastCanvas.luau
+++ b/src/CanvasDraw/FastCanvas.luau
@@ -24,7 +24,7 @@ type ParentType = GuiObject | MeshPart | Decal | Texture
 local bit32bor = bit32.bor
 local bit32lshift = bit32.lshift
 
-function FastCanvas.new(Width: number, Height: number, CanvasParent: ParentType, Blur: boolean?)
+function FastCanvas.new(Width: number, Height: number, CanvasParent: ParentType, Blur: boolean?, NO_UIAspectRatioConstraint: boolean?)
 	local IsUiParent = CanvasParent:IsA("GuiObject")
 
 	local Canvas = {} -- The canvas object
@@ -72,10 +72,13 @@ function FastCanvas.new(Width: number, Height: number, CanvasParent: ParentType,
 		if not Blur then
 			CanvasFrame.ResampleMode = Enum.ResamplerMode.Pixelated
 		end
-
-		AspectRatio = Instance.new("UIAspectRatioConstraint")
-		AspectRatio.AspectRatio = Width / Height
-		AspectRatio.Parent = CanvasFrame
+		
+		if not NO_UIAspectRatioConstraint then
+			AspectRatio = Instance.new("UIAspectRatioConstraint")
+			AspectRatio.AspectRatio = Width / Height
+			AspectRatio.Parent = CanvasFrame
+		end
+		
 
 		CanvasFrame.ImageContent = Content.fromObject(EditableImage)
 		CanvasFrame.Parent = CanvasParent

--- a/src/CanvasDraw/init.luau
+++ b/src/CanvasDraw/init.luau
@@ -394,7 +394,7 @@ type ParentType = GuiObject | MeshPart | Decal | Texture
 	
 	Resolution limit is currently 1024x1024
 ]]
-function CanvasDraw.new(Parent: ParentType, Resolution: Vector2?, CanvasColour: Color3?, Blur: boolean?)
+function CanvasDraw.new(Parent: ParentType, Resolution: Vector2?, CanvasColour: Color3?, Blur: boolean?, NO_UIAspectRatioConstraint: boolean?)
 	local Canvas = {
 		-- Modifyable properties
 		OutputWarnings = true,
@@ -453,7 +453,7 @@ function CanvasDraw.new(Parent: ParentType, Resolution: Vector2?, CanvasColour: 
 	local ResX = Canvas.CurrentResX
 	local ResY = Canvas.CurrentResY
 
-	local InternalCanvas = FastCanvas.new(ResX, ResY, Parent, Blur)
+	local InternalCanvas = FastCanvas.new(ResX, ResY, Parent, Blur, NO_UIAspectRatioConstraint)
 
 	Canvas.CurrentCanvasFrame = Parent
 


### PR DESCRIPTION
I got tired of manually removing parts of the code because I wanted to stretch the image, so I created this pull request.

CanvasDraw.new(frame,Vector2.new(100,100),Color3.new(0,0,0),nil,true)

you can add true at the end of .new() to disable UIAspectRatioConstraint.


Hope you will approve this.