### PR TITLE
Fix font name in CanvasDraw.Fonts enum

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -369,7 +369,7 @@ CanvasDraw.BlendingModes = {
 }
 
 CanvasDraw.Fonts = {
-	["3x2"] = "3x2",
+	["3x6"] = "3x6",
 	["Atari"] = "Atari",
 	["Codepage"] = "Codepage",
 	["CodepageLarge"] = "CodepageLarge",


### PR DESCRIPTION
3x6, not 3x2