### PR TITLE
Perf: optimize image rect and thin line hot paths

### DIFF
--- a/src/FastCanvas.luau
+++ b/src/FastCanvas.luau
@@ -252,23 +252,36 @@ function FastCanvas.new(Width: number, Height: number, CanvasParent: ParentType?
 			X1, X2 = X2, X1
 		end
 
-		-- Clipping
-		X1 = math.floor(math.clamp(X1, 1, Width))
-		X2 = math.floor(math.clamp(X2, 1, Width))
-		Y = math.floor(math.clamp(Y, 1, Height))
+		X1 = math.floor(X1)
+		X2 = math.floor(X2)
+		Y = math.floor(Y)
+
+		if Y < 1 or Y > Height or X2 < 1 or X1 > Width then
+			return
+		end
+
+		if X1 < 1 then
+			X1 = 1
+		end
+		if X2 > Width then
+			X2 = Width
+		end
+		if X1 > X2 then
+			return
+		end
 
 		local StartIndex = (X1 + (Y - 1) * Width) * 4 - 4
-		local EndIndex = (X2 + (Y - 1) * Width) * 4
+		local Length = (X2 - X1 + 1) * 4
 
-		local Length = EndIndex - StartIndex
+		buffer.writeu32(Grid, StartIndex, ColourU32)
+
 		local SizeStep = 4
-		local Iterations = math.ceil(math.log(Length / 4, 2))
-
-		Canvas:SetU32(X1, Y, ColourU32) -- Initial pixel to copy
-
-		-- Copy until we fill the scanline
-		for _ = 1, Iterations do
-			local Count = math.min(SizeStep, Length - SizeStep)
+		while SizeStep < Length do
+			local Count = SizeStep
+			local Remaining = Length - SizeStep
+			if Count > Remaining then
+				Count = Remaining
+			end
 
 			buffer.copy(Grid, StartIndex + SizeStep, Grid, StartIndex, Count)
 			SizeStep += Count

--- a/src/init.luau
+++ b/src/init.luau
@@ -542,8 +542,10 @@ local function DrawTexturedTrianglePlotlineModule(ax, bx, tex_su, tex_eu, tex_sv
 	if ScanlineLength == 0 then return end
 
 	local Step = 1 / ScanlineLength
-	local du = (tex_eu - tex_su) * Step
-	local dv = (tex_ev - tex_sv) * Step
+	local RangeU = tex_eu - tex_su
+	local RangeV = tex_ev - tex_sv
+	local du = RangeU * Step
+	local dv = RangeV * Step
 
 	if bx > CurrentResX then
 		ScanlineLength = CurrentResX - ax
@@ -557,8 +559,8 @@ local function DrawTexturedTrianglePlotlineModule(ax, bx, tex_su, tex_eu, tex_sv
 		t = Step * StartOffsetX
 	end
 
-	local TexU = tex_su + t * (tex_eu - tex_su)
-	local TexV = tex_sv + t * (tex_ev - tex_sv)
+	local TexU = tex_su + t * RangeU
+	local TexV = tex_sv + t * RangeV
 
 	TexU = TexU * TexResX + 1
 	TexV = TexV * TexResY + 1
@@ -566,66 +568,179 @@ local function DrawTexturedTrianglePlotlineModule(ax, bx, tex_su, tex_eu, tex_sv
 	du *= TexResX
 	dv *= TexResY
 
+	local DrawIndex = ((ax + StartOffsetX) + (Y - 1) * CurrentResX) * 4 - 4
+
 	if Brightness < 1 then
-		for j = StartOffsetX, ScanlineLength do
-			local SampleX = ClampN(FloorN(TexU), 1, TexResX)
-			local SampleY = ClampN(FloorN(TexV), 1, TexResY)
-			local DrawX = ax + j
-			local SampleIndex = (SampleX + (SampleY - 1) * TexResX) * 4 - 4
-			local DrawIndex = (DrawX + (Y - 1) * CurrentResX) * 4 - 4
+		if BlendingMode == 1 then
+			for _ = StartOffsetX, ScanlineLength do
+				local SampleX = FloorN(TexU)
+				if SampleX < 1 then
+					SampleX = 1
+				elseif SampleX > TexResX then
+					SampleX = TexResX
+				end
 
-			local R = FloorN(buffer.readu8(ImageBuffer, SampleIndex) * Brightness)
-			local G = FloorN(buffer.readu8(ImageBuffer, SampleIndex + 1) * Brightness)
-			local B = FloorN(buffer.readu8(ImageBuffer, SampleIndex + 2) * Brightness)
-			local A = buffer.readu8(ImageBuffer, SampleIndex + 3)
+				local SampleY = FloorN(TexV)
+				if SampleY < 1 then
+					SampleY = 1
+				elseif SampleY > TexResY then
+					SampleY = TexResY
+				end
 
-			if BlendingMode == 0 and A > 0 then
-				buffer.writeu8(InternalBuffer, DrawIndex, R)
-				buffer.writeu8(InternalBuffer, DrawIndex + 1, G)
-				buffer.writeu8(InternalBuffer, DrawIndex + 2, B)
-			elseif BlendingMode == 2 and A > 0 then
-				buffer.writeu8(InternalBuffer, DrawIndex, R)
-				buffer.writeu8(InternalBuffer, DrawIndex + 1, G)
-				buffer.writeu8(InternalBuffer, DrawIndex + 2, B)
-				buffer.writeu8(InternalBuffer, DrawIndex + 3, 255)
-			elseif BlendingMode == 1 then
+				local SampleIndex = (SampleX + (SampleY - 1) * TexResX) * 4 - 4
+				local R = FloorN(buffer.readu8(ImageBuffer, SampleIndex) * Brightness)
+				local G = FloorN(buffer.readu8(ImageBuffer, SampleIndex + 1) * Brightness)
+				local B = FloorN(buffer.readu8(ImageBuffer, SampleIndex + 2) * Brightness)
+				local A = buffer.readu8(ImageBuffer, SampleIndex + 3)
+
 				buffer.writeu8(InternalBuffer, DrawIndex, R)
 				buffer.writeu8(InternalBuffer, DrawIndex + 1, G)
 				buffer.writeu8(InternalBuffer, DrawIndex + 2, B)
 				buffer.writeu8(InternalBuffer, DrawIndex + 3, A)
-			end
 
-			TexU += du
-			TexV += dv
+				TexU += du
+				TexV += dv
+				DrawIndex += 4
+			end
+		elseif BlendingMode == 2 then
+			for _ = StartOffsetX, ScanlineLength do
+				local SampleX = FloorN(TexU)
+				if SampleX < 1 then
+					SampleX = 1
+				elseif SampleX > TexResX then
+					SampleX = TexResX
+				end
+
+				local SampleY = FloorN(TexV)
+				if SampleY < 1 then
+					SampleY = 1
+				elseif SampleY > TexResY then
+					SampleY = TexResY
+				end
+
+				local SampleIndex = (SampleX + (SampleY - 1) * TexResX) * 4 - 4
+				local A = buffer.readu8(ImageBuffer, SampleIndex + 3)
+				if A > 0 then
+					buffer.writeu8(InternalBuffer, DrawIndex, FloorN(buffer.readu8(ImageBuffer, SampleIndex) * Brightness))
+					buffer.writeu8(InternalBuffer, DrawIndex + 1, FloorN(buffer.readu8(ImageBuffer, SampleIndex + 1) * Brightness))
+					buffer.writeu8(InternalBuffer, DrawIndex + 2, FloorN(buffer.readu8(ImageBuffer, SampleIndex + 2) * Brightness))
+					buffer.writeu8(InternalBuffer, DrawIndex + 3, 255)
+				end
+
+				TexU += du
+				TexV += dv
+				DrawIndex += 4
+			end
+		else
+			for _ = StartOffsetX, ScanlineLength do
+				local SampleX = FloorN(TexU)
+				if SampleX < 1 then
+					SampleX = 1
+				elseif SampleX > TexResX then
+					SampleX = TexResX
+				end
+
+				local SampleY = FloorN(TexV)
+				if SampleY < 1 then
+					SampleY = 1
+				elseif SampleY > TexResY then
+					SampleY = TexResY
+				end
+
+				local SampleIndex = (SampleX + (SampleY - 1) * TexResX) * 4 - 4
+				local A = buffer.readu8(ImageBuffer, SampleIndex + 3)
+				if A > 0 then
+					buffer.writeu8(InternalBuffer, DrawIndex, FloorN(buffer.readu8(ImageBuffer, SampleIndex) * Brightness))
+					buffer.writeu8(InternalBuffer, DrawIndex + 1, FloorN(buffer.readu8(ImageBuffer, SampleIndex + 1) * Brightness))
+					buffer.writeu8(InternalBuffer, DrawIndex + 2, FloorN(buffer.readu8(ImageBuffer, SampleIndex + 2) * Brightness))
+				end
+
+				TexU += du
+				TexV += dv
+				DrawIndex += 4
+			end
 		end
 	else
-		for j = StartOffsetX, ScanlineLength do
-			local SampleX = ClampN(FloorN(TexU), 1, TexResX)
-			local SampleY = ClampN(FloorN(TexV), 1, TexResY)
-			local DrawX = ax + j
-			local SampleIndex = (SampleX + (SampleY - 1) * TexResX) * 4 - 4
-			local DrawIndex = (DrawX + (Y - 1) * CurrentResX) * 4 - 4
-			local A = buffer.readu8(ImageBuffer, SampleIndex + 3)
-
-			if BlendingMode == 0 then
-				if A > 0 then
-					buffer.writeu8(InternalBuffer, DrawIndex, buffer.readu8(ImageBuffer, SampleIndex))
-					buffer.writeu8(InternalBuffer, DrawIndex + 1, buffer.readu8(ImageBuffer, SampleIndex + 1))
-					buffer.writeu8(InternalBuffer, DrawIndex + 2, buffer.readu8(ImageBuffer, SampleIndex + 2))
+		if BlendingMode == 1 then
+			for _ = StartOffsetX, ScanlineLength do
+				local SampleX = FloorN(TexU)
+				if SampleX < 1 then
+					SampleX = 1
+				elseif SampleX > TexResX then
+					SampleX = TexResX
 				end
-			elseif BlendingMode == 2 then
+
+				local SampleY = FloorN(TexV)
+				if SampleY < 1 then
+					SampleY = 1
+				elseif SampleY > TexResY then
+					SampleY = TexResY
+				end
+
+				local SampleIndex = (SampleX + (SampleY - 1) * TexResX) * 4 - 4
+				buffer.writeu32(InternalBuffer, DrawIndex, buffer.readu32(ImageBuffer, SampleIndex))
+
+				TexU += du
+				TexV += dv
+				DrawIndex += 4
+			end
+		elseif BlendingMode == 2 then
+			for _ = StartOffsetX, ScanlineLength do
+				local SampleX = FloorN(TexU)
+				if SampleX < 1 then
+					SampleX = 1
+				elseif SampleX > TexResX then
+					SampleX = TexResX
+				end
+
+				local SampleY = FloorN(TexV)
+				if SampleY < 1 then
+					SampleY = 1
+				elseif SampleY > TexResY then
+					SampleY = TexResY
+				end
+
+				local SampleIndex = (SampleX + (SampleY - 1) * TexResX) * 4 - 4
+				local A = buffer.readu8(ImageBuffer, SampleIndex + 3)
 				if A > 0 then
 					buffer.writeu8(InternalBuffer, DrawIndex, buffer.readu8(ImageBuffer, SampleIndex))
 					buffer.writeu8(InternalBuffer, DrawIndex + 1, buffer.readu8(ImageBuffer, SampleIndex + 1))
 					buffer.writeu8(InternalBuffer, DrawIndex + 2, buffer.readu8(ImageBuffer, SampleIndex + 2))
 					buffer.writeu8(InternalBuffer, DrawIndex + 3, 255)
 				end
-			elseif BlendingMode == 1 then
-				buffer.writeu32(InternalBuffer, DrawIndex, buffer.readu32(ImageBuffer, SampleIndex))
-			end
 
-			TexU += du
-			TexV += dv
+				TexU += du
+				TexV += dv
+				DrawIndex += 4
+			end
+		else
+			for _ = StartOffsetX, ScanlineLength do
+				local SampleX = FloorN(TexU)
+				if SampleX < 1 then
+					SampleX = 1
+				elseif SampleX > TexResX then
+					SampleX = TexResX
+				end
+
+				local SampleY = FloorN(TexV)
+				if SampleY < 1 then
+					SampleY = 1
+				elseif SampleY > TexResY then
+					SampleY = TexResY
+				end
+
+				local SampleIndex = (SampleX + (SampleY - 1) * TexResX) * 4 - 4
+				local A = buffer.readu8(ImageBuffer, SampleIndex + 3)
+				if A > 0 then
+					buffer.writeu8(InternalBuffer, DrawIndex, buffer.readu8(ImageBuffer, SampleIndex))
+					buffer.writeu8(InternalBuffer, DrawIndex + 1, buffer.readu8(ImageBuffer, SampleIndex + 1))
+					buffer.writeu8(InternalBuffer, DrawIndex + 2, buffer.readu8(ImageBuffer, SampleIndex + 2))
+				end
+
+				TexU += du
+				TexV += dv
+				DrawIndex += 4
+			end
 		end
 	end
 end
@@ -649,6 +764,8 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 		GridColour = Color3.new(1, 1, 1),
 		AutoRenderFpsLimit = 0,
 		AlphaBlendingMode = CanvasDraw.BlendingModes.Replace,
+		_ScratchSampleRows = {},
+		_ScratchDrawRows = {},
 
 		-- Read only
 		Resolution = Vector2New(100, 100),
@@ -872,48 +989,81 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 			dy = Y1 - Y2
 		end
 
-		local err, e2 = dx-dy, nil
+		local err, e2 = dx - dy, nil
 
-		local function PlotPixel()
-			if X1 <= ResX and Y1 <= ResY and X1 > 0 and Y1 > 0 then
-				if BlendingMode == 0 and Alpha > 0 then -- Normal
-					local ColR = R
-					local ColG = G 
-					local ColB = B 
+		if BlendingMode == 1 or Alpha >= 1 then
+			local SetU32 = InternalCanvas.SetU32
 
-					if Alpha < 1 then
-						local BgR, BgG, BgB = InternalCanvas:GetRGB(X1, Y1)
+			while not (X1 == X2 and Y1 == Y2) do
+				e2 = err + err
+				if e2 > -dy then
+					err -= dy
+					X1 += sx
+				end
+				if e2 < dx then
+					err += dx
+					Y1 += sy
+				end
 
-						ColR = Lerp(BgR, R, Alpha)
-						ColG = Lerp(BgG, G, Alpha)
-						ColB = Lerp(BgB, B, Alpha)
-					end
-
-					InternalCanvas:SetRGB(X1, Y1, ColR, ColG, ColB)
-				elseif BlendingMode == 2 and Alpha < 1 then
-					-- Add blending
-					local BgA = CanvasGetAlpha(Canvas, X1, Y1)
-					CanvasSetRGBA(Canvas, X1, Y1, R, G, B, math.min(BgA + Alpha, 1))
-				elseif BlendingMode == 1 or Alpha >= 1 then
-					InternalCanvas:SetU32(X1, Y1, ColourU32)
+				if X1 <= ResX and Y1 <= ResY and X1 > 0 and Y1 > 0 then
+					SetU32(InternalCanvas, X1, Y1, ColourU32)
 				end
 			end
-		end
+		elseif BlendingMode == 2 and Alpha < 1 then
+			while not (X1 == X2 and Y1 == Y2) do
+				e2 = err + err
+				if e2 > -dy then
+					err -= dy
+					X1 += sx
+				end
+				if e2 < dx then
+					err += dx
+					Y1 += sy
+				end
 
-		-- Start point
-		--PlotPixel()
+				if X1 <= ResX and Y1 <= ResY and X1 > 0 and Y1 > 0 then
+					local BgA = CanvasGetAlpha(Canvas, X1, Y1)
+					CanvasSetRGBA(Canvas, X1, Y1, R, G, B, math.min(BgA + Alpha, 1))
+				end
+			end
+		elseif BlendingMode == 0 and Alpha > 0 then
+			local SetRGB = InternalCanvas.SetRGB
+			local GetRGB = InternalCanvas.GetRGB
 
-		while not(X1 == X2 and Y1 == Y2) do
-			e2 = err + err
-			if e2 > -dy then
-				err -= dy
-				X1 += sx
+			if Alpha < 1 then
+				while not (X1 == X2 and Y1 == Y2) do
+					e2 = err + err
+					if e2 > -dy then
+						err -= dy
+						X1 += sx
+					end
+					if e2 < dx then
+						err += dx
+						Y1 += sy
+					end
+
+					if X1 <= ResX and Y1 <= ResY and X1 > 0 and Y1 > 0 then
+						local BgR, BgG, BgB = GetRGB(InternalCanvas, X1, Y1)
+						SetRGB(InternalCanvas, X1, Y1, Lerp(BgR, R, Alpha), Lerp(BgG, G, Alpha), Lerp(BgB, B, Alpha))
+					end
+				end
+			else
+				while not (X1 == X2 and Y1 == Y2) do
+					e2 = err + err
+					if e2 > -dy then
+						err -= dy
+						X1 += sx
+					end
+					if e2 < dx then
+						err += dx
+						Y1 += sy
+					end
+
+					if X1 <= ResX and Y1 <= ResY and X1 > 0 and Y1 > 0 then
+						SetRGB(InternalCanvas, X1, Y1, R, G, B)
+					end
+				end
 			end
-			if e2 < dx then
-				err += dx
-				Y1 += sy
-			end
-			PlotPixel()
 		end
 	end
 	
@@ -1747,8 +1897,6 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 
 		if X > ResX or Y > ResY then return end -- No need to draw if out of bounds
 
-		local GetImgU32 = ImageData.GetU32
-		local GetImgRGBA = ImageData.GetRGBA
 		local ImageBuffer = ImageData.ImageBuffer
 
 		local InternalBuffer = InternalCanvas.Buffer
@@ -1802,68 +1950,151 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 			end
 		else
 			-- Draw image with scale adjustments (more expensive)
-			local CurrentStepX, CurrentStepY = 0, 0
-
-
-
 			local StepX = 1 / ScaleX
 			local StepY = 1 / ScaleY
 
-			-- Clip X
-			if X < 1 then
-				CurrentStepX = (-X + 1) * StepX
-			end
+			if BlendingMode == 0 and TransparencyBlending then
+				local CurrentStepX = 0
+				if X < 1 then
+					CurrentStepX = (-X + 1) * StepX
+				end
 
-			for ImgX = StartX, ScaledImageResX do
-				CurrentStepX += StepX
-				local SampleX = CeilN(CurrentStepX)
-				local PlacementX = X + ImgX - 1
+				local SampleRows = self._ScratchSampleRows
+				local DrawRows = self._ScratchDrawRows
+				local RowCount = 0
+				local CurrentStepY = 0
 
-				CurrentStepY = 0
-
-				-- Clip Y
 				if Y < 1 then
 					CurrentStepY = (-Y + 1) * StepY
 				end
 
 				for ImgY = StartY, ScaledImageResY do
 					CurrentStepY += StepY
-					local SampleY = CeilN(CurrentStepY)
+					local SampleY = ClampN(CeilN(CurrentStepY), 1, ImageResolutionY)
 					local PlacementY = Y + ImgY - 1
+					RowCount += 1
+					SampleRows[RowCount] = (SampleY - 1) * ImageResolutionX * 4
+					DrawRows[RowCount] = (PlacementY - 1) * ResX * 4
+				end
 
-					if BlendingMode == 0 and TransparencyBlending then -- Normal blending
-						local ImgIndex = (SampleX + (SampleY - 1) * ImageResolutionX) * 4 - 4
+				for ImgX = StartX, ScaledImageResX do
+					CurrentStepX += StepX
+					local SampleX = ClampN(CeilN(CurrentStepX), 1, ImageResolutionX)
+					local PlacementX = X + ImgX - 1
+					local SampleXOffset = (SampleX - 1) * 4
+					local DrawXOffset = (PlacementX - 1) * 4
+
+					for Row = 1, RowCount do
+						local ImgIndex = SampleXOffset + SampleRows[Row]
 						local ImgA = buffer.readu8(ImageBuffer, ImgIndex + 3)
 
-						if ImgA == 0 then -- No need to do any calculations for completely transparent pixels
-							continue
+						if ImgA ~= 0 then
+							local DrawIndex = DrawXOffset + DrawRows[Row]
+							local ImgR = buffer.readu8(ImageBuffer, ImgIndex)
+							local ImgG = buffer.readu8(ImageBuffer, ImgIndex + 1)
+							local ImgB = buffer.readu8(ImageBuffer, ImgIndex + 2)
+
+							if ImgA < 255 then
+								local BgR = buffer.readu8(InternalBuffer, DrawIndex)
+								local BgG = buffer.readu8(InternalBuffer, DrawIndex + 1)
+								local BgB = buffer.readu8(InternalBuffer, DrawIndex + 2)
+								local InvA = 255 - ImgA
+
+								ImgR = FloorN((BgR * InvA + ImgR * ImgA) / 255)
+								ImgG = FloorN((BgG * InvA + ImgG * ImgA) / 255)
+								ImgB = FloorN((BgB * InvA + ImgB * ImgA) / 255)
+							end
+
+							buffer.writeu8(InternalBuffer, DrawIndex, ImgR)
+							buffer.writeu8(InternalBuffer, DrawIndex + 1, ImgG)
+							buffer.writeu8(InternalBuffer, DrawIndex + 2, ImgB)
 						end
+					end
+				end
+			elseif BlendingMode == 2 and TransparencyBlending then
+				local CurrentStepX = 0
+				if X < 1 then
+					CurrentStepX = (-X + 1) * StepX
+				end
 
-						local DrawIndex = (PlacementX + (PlacementY - 1) * ResX) * 4 - 4
-						local ImgR = buffer.readu8(ImageBuffer, ImgIndex)
-						local ImgG = buffer.readu8(ImageBuffer, ImgIndex + 1)
-						local ImgB = buffer.readu8(ImageBuffer, ImgIndex + 2)
+				local SampleRows = self._ScratchSampleRows
+				local DrawRows = self._ScratchDrawRows
+				local RowCount = 0
+				local CurrentStepY = 0
 
-						if ImgA < 255 then
-							local BgR = buffer.readu8(InternalBuffer, DrawIndex)
-							local BgG = buffer.readu8(InternalBuffer, DrawIndex + 1)
-							local BgB = buffer.readu8(InternalBuffer, DrawIndex + 2)
-							local InvA = 255 - ImgA
+				if Y < 1 then
+					CurrentStepY = (-Y + 1) * StepY
+				end
 
-							ImgR = FloorN((BgR * InvA + ImgR * ImgA) / 255)
-							ImgG = FloorN((BgG * InvA + ImgG * ImgA) / 255)
-							ImgB = FloorN((BgB * InvA + ImgB * ImgA) / 255)
+				for ImgY = StartY, ScaledImageResY do
+					CurrentStepY += StepY
+					local SampleY = ClampN(CeilN(CurrentStepY), 1, ImageResolutionY)
+					local PlacementY = Y + ImgY - 1
+					RowCount += 1
+					SampleRows[RowCount] = (SampleY - 1) * ImageResolutionX * 4
+					DrawRows[RowCount] = (PlacementY - 1) * ResX * 4
+				end
+
+				for ImgX = StartX, ScaledImageResX do
+					CurrentStepX += StepX
+					local SampleX = ClampN(CeilN(CurrentStepX), 1, ImageResolutionX)
+					local PlacementX = X + ImgX - 1
+					local SampleXOffset = (SampleX - 1) * 4
+					local DrawXOffset = (PlacementX - 1) * 4
+
+					for Row = 1, RowCount do
+						local ImgIndex = SampleXOffset + SampleRows[Row]
+						local ImgA = buffer.readu8(ImageBuffer, ImgIndex + 3)
+						if ImgA > 0 then
+							local DrawIndex = DrawXOffset + DrawRows[Row]
+							local BgA = buffer.readu8(InternalBuffer, DrawIndex + 3)
+							local NewA = BgA + ImgA
+							if NewA > 255 then
+								NewA = 255
+							end
+
+							buffer.writeu8(InternalBuffer, DrawIndex, buffer.readu8(ImageBuffer, ImgIndex))
+							buffer.writeu8(InternalBuffer, DrawIndex + 1, buffer.readu8(ImageBuffer, ImgIndex + 1))
+							buffer.writeu8(InternalBuffer, DrawIndex + 2, buffer.readu8(ImageBuffer, ImgIndex + 2))
+							buffer.writeu8(InternalBuffer, DrawIndex + 3, NewA)
 						end
+					end
+				end
+			else
+				local CurrentStepX = 0
+				if X < 1 then
+					CurrentStepX = (-X + 1) * StepX
+				end
 
-						buffer.writeu8(InternalBuffer, DrawIndex, ImgR)
-						buffer.writeu8(InternalBuffer, DrawIndex + 1, ImgG)
-						buffer.writeu8(InternalBuffer, DrawIndex + 2, ImgB)
-					elseif BlendingMode == 2 and TransparencyBlending then
-						local ImgR, ImgG, ImgB, ImgA = GetImgRGBA(ImageData, SampleX, SampleY)
-						local BgA = CanvasGetAlpha(Canvas, PlacementX, PlacementY)
-						CanvasSetRGBA(Canvas, PlacementX, PlacementY, ImgR, ImgG, ImgB, math.min(ImgA + BgA, 1))
-					else -- Replace/No blending
-						CanvasSetU32(Canvas, PlacementX, PlacementY, GetImgU32(ImageData, SampleX, SampleY))
+				local SampleRows = self._ScratchSampleRows
+				local DrawRows = self._ScratchDrawRows
+				local RowCount = 0
+				local CurrentStepY = 0
+
+				if Y < 1 then
+					CurrentStepY = (-Y + 1) * StepY
+				end
+
+				for ImgY = StartY, ScaledImageResY do
+					CurrentStepY += StepY
+					local SampleY = ClampN(CeilN(CurrentStepY), 1, ImageResolutionY)
+					local PlacementY = Y + ImgY - 1
+					RowCount += 1
+					SampleRows[RowCount] = (SampleY - 1) * ImageResolutionX * 4
+					DrawRows[RowCount] = (PlacementY - 1) * ResX * 4
+				end
+
+				for ImgX = StartX, ScaledImageResX do
+					CurrentStepX += StepX
+					local SampleX = ClampN(CeilN(CurrentStepX), 1, ImageResolutionX)
+					local PlacementX = X + ImgX - 1
+					local SampleXOffset = (SampleX - 1) * 4
+					local DrawXOffset = (PlacementX - 1) * 4
+
+					for Row = 1, RowCount do
+						local ImgIndex = SampleXOffset + SampleRows[Row]
+						local DrawIndex = DrawXOffset + DrawRows[Row]
+						buffer.writeu32(InternalBuffer, DrawIndex, buffer.readu32(ImageBuffer, ImgIndex))
 					end
 				end
 			end
@@ -2575,9 +2806,55 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 		ImageData: ImageData, X: number, Y: number, RectOffsetX: number, RectOffsetY: number, RectWidth: number, RectHeight: number
 	)
 		local ImageWidth = ImageData.Width
-		local SampleBuffer = ImageData:GetBuffer(1 + RectOffsetX, 1 + RectOffsetY, RectWidth, RectHeight)
+		local ImageHeight = ImageData.Height
 
-		Canvas:SetBuffer(SampleBuffer, X, Y, RectWidth, RectHeight)
+		if RectOffsetX < 0 or RectOffsetY < 0 or RectOffsetX + RectWidth > ImageWidth or RectOffsetY + RectHeight > ImageHeight then
+			warn("'Canvas:DrawFastImageRectXY()' failed as the given rect is outside the ImageData bounds")
+			return
+		end
+
+		local CanvasWidth = self.CurrentResX
+		local CanvasHeight = self.CurrentResY
+		local ScaledWidth = RectWidth
+		local OffsetY = 0
+		local OffsetX = 0
+
+		if X < 1 then
+			OffsetX = 1 + -X
+			ScaledWidth -= 1 + -X
+		end
+
+		if X + RectWidth - 1 > CanvasWidth then
+			ScaledWidth -= (X + RectWidth - 2) - CanvasWidth + 1
+		end
+
+		if Y < 1 then
+			OffsetY = 1 + -Y
+		end
+
+		local SampleStartX = 1 + OffsetX
+
+		if SampleStartX > RectWidth then return end
+		if X > CanvasWidth then return end
+
+		local DrawBuffer = self.Buffer
+		local SourceBuffer = ImageData.ImageBuffer
+
+		for ImgY = 1 + OffsetY, RectHeight do
+			local PlacementY = Y + ImgY - 1
+			if PlacementY > CanvasHeight then break end
+
+			local ImageBufferStartIndex = ((RectOffsetX + SampleStartX) + (RectOffsetY + ImgY - 1) * ImageWidth) * 4 - 4
+			local DrawStartIndex = (X + OffsetX + (PlacementY - 1) * CanvasWidth) * 4 - 4
+
+			buffer.copy(
+				DrawBuffer,
+				DrawStartIndex,
+				SourceBuffer,
+				ImageBufferStartIndex,
+				ScaledWidth * 4
+			)
+		end
 	end
 
 	--[[
@@ -2650,15 +2927,23 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 		-- pick rounding fn once instead of branching every pixel
 		local RoundX = FlipX and CeilN or FloorN
 		local RoundY = FlipY and CeilN or FloorN
+		local Span = EndX - StartX + 1
+		local SampleRows = self._ScratchSampleRows
+
+		local SampleX = SampleXStart
+		for i = 1, Span do
+			SampleRows[i] = RoundX(SampleX)
+			SampleX += SampleXStep
+		end
 
 		-- y outer x inner so the inner loop hits sequential memory, blending branch stays outside
 		if BlendingMode == 0 then -- normal
 			local SampleY = SampleYStart
 			for DrawY = StartY, EndY do
 				local RoundSampleY = RoundY(SampleY)
-				local SampleX = SampleXStart
-				for DrawX = StartX, EndX do
-					local R, G, B, A = ImgGetRGBA(ImageData, RoundX(SampleX), RoundSampleY)
+				local DrawX = StartX
+				for i = 1, Span do
+					local R, G, B, A = ImgGetRGBA(ImageData, SampleRows[i], RoundSampleY)
 
 					if A ~= 0 then
 						if A < 1 then
@@ -2670,31 +2955,41 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 						CanvasSetRGB(InternalCanvas, DrawX, DrawY, R, G, B)
 					end
 
-					SampleX += SampleXStep
+					DrawX += 1
 				end
 				SampleY += SampleYStep
 			end
 		elseif BlendingMode == 1 then -- replace
+			local CanvasWidth = self.CurrentResX
+			local ImageBuffer = ImageData.ImageBuffer
+			local DrawBuffer = self.Buffer
+			local ImageStride = ImageSizeX * 4
+
 			local SampleY = SampleYStart
 			for DrawY = StartY, EndY do
 				local RoundSampleY = RoundY(SampleY)
-				local SampleX = SampleXStart
-				for DrawX = StartX, EndX do
-					CanvasSetU32(InternalCanvas, DrawX, DrawY, ImgGetU32(ImageData, RoundX(SampleX), RoundSampleY))
-					SampleX += SampleXStep
+				local SrcRowStart = (RoundSampleY - 1) * ImageStride
+				local DrawIndex = (StartX + (DrawY - 1) * CanvasWidth) * 4 - 4
+
+				for i = 1, Span do
+					local SrcX = SampleRows[i]
+					local SrcIndex = SrcRowStart + (SrcX - 1) * 4
+					buffer.writeu32(DrawBuffer, DrawIndex, buffer.readu32(ImageBuffer, SrcIndex))
+					DrawIndex += 4
 				end
+
 				SampleY += SampleYStep
 			end
 		elseif BlendingMode == 2 then -- add (note: original passed raw unrounded coords here, this fixes that)
 			local SampleY = SampleYStart
 			for DrawY = StartY, EndY do
 				local RoundSampleY = RoundY(SampleY)
-				local SampleX = SampleXStart
-				for DrawX = StartX, EndX do
-					local R, G, B, A = ImgGetRGBA(ImageData, RoundX(SampleX), RoundSampleY)
+				local DrawX = StartX
+				for i = 1, Span do
+					local R, G, B, A = ImgGetRGBA(ImageData, SampleRows[i], RoundSampleY)
 					local BgA = CanvasGetAlpha(Canvas, DrawX, DrawY)
 					CanvasSetRGBA(Canvas, DrawX, DrawY, R, G, B, math.min(BgA + A, 1))
-					SampleX += SampleXStep
+					DrawX += 1
 				end
 				SampleY += SampleYStep
 			end
@@ -2772,48 +3067,99 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 				dy = Y1 - Y2
 			end
 
-			local err, e2 = dx-dy, nil
+			local err, e2 = dx - dy, nil
 
-			local function PlotPixel()
+			if BlendingMode == 1 or Alpha >= 1 then
+				local SetU32 = InternalCanvas.SetU32
+
 				if X1 <= ResX and Y1 <= ResY and X1 > 0 and Y1 > 0 then
-					if BlendingMode == 0 and Alpha > 0 then -- Normal
-						local R2 = ColR
-						local G2 = ColG 
-						local B2 = ColB
+					SetU32(InternalCanvas, X1, Y1, ColourU32)
+				end
 
-						if Alpha < 1 then
-							local BgR, BgG, BgB = InternalCanvas:GetRGB(X1, Y1)
+				while not (X1 == X2 and Y1 == Y2) do
+					e2 = err + err
+					if e2 > -dy then
+						err -= dy
+						X1 += sx
+					end
+					if e2 < dx then
+						err += dx
+						Y1 += sy
+					end
 
-							R2 = Lerp(BgR, ColR, Alpha)
-							G2 = Lerp(BgG, ColG, Alpha)
-							B2 = Lerp(BgB, ColB, Alpha)
-						end
-
-						InternalCanvas:SetRGB(X1, Y1, R2, G2, B2)
-					elseif BlendingMode == 2 and Alpha < 1 then
-						-- Add blending
-						local BgA = CanvasGetAlpha(Canvas, X1, Y1)
-						CanvasSetRGBA(Canvas, X1, Y1, ColR, ColG, ColB, math.min(BgA + Alpha, 1))
-					elseif BlendingMode == 1 or Alpha >= 1 then
-						InternalCanvas:SetU32(X1, Y1, ColourU32)
+					if X1 <= ResX and Y1 <= ResY and X1 > 0 and Y1 > 0 then
+						SetU32(InternalCanvas, X1, Y1, ColourU32)
 					end
 				end
-			end
-
-			-- Start point
-			PlotPixel()
-
-			while not(X1 == X2 and Y1 == Y2) do
-				e2 = err + err
-				if e2 > -dy then
-					err -= dy
-					X1 += sx
+			elseif BlendingMode == 2 and Alpha < 1 then
+				if X1 <= ResX and Y1 <= ResY and X1 > 0 and Y1 > 0 then
+					local BgA = CanvasGetAlpha(Canvas, X1, Y1)
+					CanvasSetRGBA(Canvas, X1, Y1, ColR, ColG, ColB, math.min(BgA + Alpha, 1))
 				end
-				if e2 < dx then
-					err += dx
-					Y1 += sy
+
+				while not (X1 == X2 and Y1 == Y2) do
+					e2 = err + err
+					if e2 > -dy then
+						err -= dy
+						X1 += sx
+					end
+					if e2 < dx then
+						err += dx
+						Y1 += sy
+					end
+
+					if X1 <= ResX and Y1 <= ResY and X1 > 0 and Y1 > 0 then
+						local BgA = CanvasGetAlpha(Canvas, X1, Y1)
+						CanvasSetRGBA(Canvas, X1, Y1, ColR, ColG, ColB, math.min(BgA + Alpha, 1))
+					end
 				end
-				PlotPixel()
+			elseif BlendingMode == 0 and Alpha > 0 then
+				local SetRGB = InternalCanvas.SetRGB
+				local GetRGB = InternalCanvas.GetRGB
+
+				if Alpha < 1 then
+					if X1 <= ResX and Y1 <= ResY and X1 > 0 and Y1 > 0 then
+						local BgR, BgG, BgB = GetRGB(InternalCanvas, X1, Y1)
+						SetRGB(InternalCanvas, X1, Y1, Lerp(BgR, ColR, Alpha), Lerp(BgG, ColG, Alpha), Lerp(BgB, ColB, Alpha))
+					end
+
+					while not (X1 == X2 and Y1 == Y2) do
+						e2 = err + err
+						if e2 > -dy then
+							err -= dy
+							X1 += sx
+						end
+						if e2 < dx then
+							err += dx
+							Y1 += sy
+						end
+
+						if X1 <= ResX and Y1 <= ResY and X1 > 0 and Y1 > 0 then
+							local BgR, BgG, BgB = GetRGB(InternalCanvas, X1, Y1)
+							SetRGB(InternalCanvas, X1, Y1, Lerp(BgR, ColR, Alpha), Lerp(BgG, ColG, Alpha), Lerp(BgB, ColB, Alpha))
+						end
+					end
+				else
+					if X1 <= ResX and Y1 <= ResY and X1 > 0 and Y1 > 0 then
+						SetRGB(InternalCanvas, X1, Y1, ColR, ColG, ColB)
+					end
+
+					while not (X1 == X2 and Y1 == Y2) do
+						e2 = err + err
+						if e2 > -dy then
+							err -= dy
+							X1 += sx
+						end
+						if e2 < dx then
+							err += dx
+							Y1 += sy
+						end
+
+						if X1 <= ResX and Y1 <= ResY and X1 > 0 and Y1 > 0 then
+							SetRGB(InternalCanvas, X1, Y1, ColR, ColG, ColB)
+						end
+					end
+				end
 			end
 		else -- Custom polygon based thick line
 			LineType = LineType or (type(LineType) == "nil" and 1) -- Ensures if the parameter is empty, its on circle by default

--- a/src/init.luau
+++ b/src/init.luau
@@ -1816,7 +1816,7 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 
 			for ImgX = StartX, ScaledImageResX do
 				CurrentStepX += StepX
-				local SampleX = CeilN(CurrentStepX)
+				local SampleX = ClampN(CeilN(CurrentStepX), 1, ImageResolutionX)
 				local PlacementX = X + ImgX - 1
 
 				CurrentStepY = 0
@@ -1828,7 +1828,7 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 
 				for ImgY = StartY, ScaledImageResY do
 					CurrentStepY += StepY
-					local SampleY = CeilN(CurrentStepY)
+					local SampleY = ClampN(CeilN(CurrentStepY), 1, ImageResolutionY)
 					local PlacementY = Y + ImgY - 1
 
 					if BlendingMode == 0 and TransparencyBlending then -- Normal blending

--- a/src/init.luau
+++ b/src/init.luau
@@ -466,6 +466,170 @@ local function XYToPixelIndex(X, Y, ResolutionX)
 	return X + (Y - 1) * ResolutionX
 end
 
+-- module scoped on purpose avoids per draw closure allocation churn
+local function DrawTrianglePlotlineModule(ax, bx, Y, CurrentResX, DrawScanline, ColR, ColG, ColB, Alpha, ColourU32)
+	if ax > bx then
+		ax, bx = bx, ax
+	end
+
+	local StartX = math.max(1, ax)
+	local EndX = math.min(CurrentResX, bx)
+
+	DrawScanline(StartX, EndX, Y, ColR, ColG, ColB, Alpha, ColourU32)
+end
+
+-- module scoped on purpose avoids per draw closure allocation churn
+local function FillTopTriangleModule(X1, Y1, X2, Y2, X3, Y3, YMin, YMax, CurrentResX, DrawScanline, ColR, ColG, ColB, Alpha, ColourU32)
+	local invslope1 = (X2 - X1) / (Y2 - Y1)
+	local invslope2 = (X3 - X1) / (Y3 - Y1)
+
+	local startY = math.max(Y1, YMin)
+	local endY = math.min(Y2 - 1, YMax)
+
+	local curx1 = X1 + invslope1 * (startY - Y1)
+	local curx2 = X1 + invslope2 * (startY - Y1)
+
+	for scanlineY = startY, endY do
+		local ax = RoundN(curx1)
+		local bx = RoundN(curx2)
+		DrawTrianglePlotlineModule(ax, bx, scanlineY, CurrentResX, DrawScanline, ColR, ColG, ColB, Alpha, ColourU32)
+		curx1 += invslope1
+		curx2 += invslope2
+	end
+end
+
+-- module scoped on purpose avoids per draw closure allocation churn
+local function FillBottomTriangleModule(X1, Y1, X2, Y2, X3, Y3, YMin, YMax, OrigX1, OrigX2, OrigX3, OrigY1, OrigY3, CurrentResX, DrawScanline, ColR, ColG, ColB, Alpha, ColourU32)
+	local invslope1 = (X3 - X1) / (Y3 - Y1)
+	local invslope2 = (X3 - X2) / (Y3 - Y2)
+
+	local startY = math.max(Y2, YMin)
+	local endY = math.min(Y3, YMax)
+
+	local curx1 = X1 + invslope1 * (startY - Y1)
+	local curx2 = X2 + invslope2 * (startY - Y2)
+
+	if invslope1 >= math.huge or invslope1 ~= invslope1 then
+		invslope1 = 0
+		invslope2 = 0
+
+		if OrigY1 == OrigY3 then
+			curx1 = OrigX1
+		else
+			curx1 = OrigX2
+		end
+		curx2 = OrigX3
+	end
+
+	for scanlineY = startY, endY do
+		local ax = RoundN(curx1)
+		local bx = RoundN(curx2)
+		DrawTrianglePlotlineModule(ax, bx, scanlineY, CurrentResX, DrawScanline, ColR, ColG, ColB, Alpha, ColourU32)
+		curx1 += invslope1
+		curx2 += invslope2
+	end
+end
+
+-- module scoped on purpose avoids per draw closure allocation churn
+local function DrawTexturedTrianglePlotlineModule(ax, bx, tex_su, tex_eu, tex_sv, tex_ev, Y, CurrentResX, TexResX, TexResY, Brightness, BlendingMode, ImageBuffer, InternalBuffer)
+	if ax > bx then
+		ax, bx = Swap(ax, bx)
+		tex_su, tex_eu = Swap(tex_su, tex_eu)
+		tex_sv, tex_ev = Swap(tex_sv, tex_ev)
+	end
+
+	local ScanlineLength = bx - ax
+	if ScanlineLength == 0 then return end
+
+	local Step = 1 / ScanlineLength
+	local du = (tex_eu - tex_su) * Step
+	local dv = (tex_ev - tex_sv) * Step
+
+	if bx > CurrentResX then
+		ScanlineLength = CurrentResX - ax
+	end
+
+	local StartOffsetX = 0
+	local t = 0
+
+	if ax < 1 then
+		StartOffsetX = -(ax - 1)
+		t = Step * StartOffsetX
+	end
+
+	local TexU = tex_su + t * (tex_eu - tex_su)
+	local TexV = tex_sv + t * (tex_ev - tex_sv)
+
+	TexU = TexU * TexResX + 1
+	TexV = TexV * TexResY + 1
+
+	du *= TexResX
+	dv *= TexResY
+
+	if Brightness < 1 then
+		for j = StartOffsetX, ScanlineLength do
+			local SampleX = ClampN(FloorN(TexU), 1, TexResX)
+			local SampleY = ClampN(FloorN(TexV), 1, TexResY)
+			local DrawX = ax + j
+			local SampleIndex = (SampleX + (SampleY - 1) * TexResX) * 4 - 4
+			local DrawIndex = (DrawX + (Y - 1) * CurrentResX) * 4 - 4
+
+			local R = FloorN(buffer.readu8(ImageBuffer, SampleIndex) * Brightness)
+			local G = FloorN(buffer.readu8(ImageBuffer, SampleIndex + 1) * Brightness)
+			local B = FloorN(buffer.readu8(ImageBuffer, SampleIndex + 2) * Brightness)
+			local A = buffer.readu8(ImageBuffer, SampleIndex + 3)
+
+			if BlendingMode == 0 and A > 0 then
+				buffer.writeu8(InternalBuffer, DrawIndex, R)
+				buffer.writeu8(InternalBuffer, DrawIndex + 1, G)
+				buffer.writeu8(InternalBuffer, DrawIndex + 2, B)
+			elseif BlendingMode == 2 and A > 0 then
+				buffer.writeu8(InternalBuffer, DrawIndex, R)
+				buffer.writeu8(InternalBuffer, DrawIndex + 1, G)
+				buffer.writeu8(InternalBuffer, DrawIndex + 2, B)
+				buffer.writeu8(InternalBuffer, DrawIndex + 3, 255)
+			elseif BlendingMode == 1 then
+				buffer.writeu8(InternalBuffer, DrawIndex, R)
+				buffer.writeu8(InternalBuffer, DrawIndex + 1, G)
+				buffer.writeu8(InternalBuffer, DrawIndex + 2, B)
+				buffer.writeu8(InternalBuffer, DrawIndex + 3, A)
+			end
+
+			TexU += du
+			TexV += dv
+		end
+	else
+		for j = StartOffsetX, ScanlineLength do
+			local SampleX = ClampN(FloorN(TexU), 1, TexResX)
+			local SampleY = ClampN(FloorN(TexV), 1, TexResY)
+			local DrawX = ax + j
+			local SampleIndex = (SampleX + (SampleY - 1) * TexResX) * 4 - 4
+			local DrawIndex = (DrawX + (Y - 1) * CurrentResX) * 4 - 4
+			local A = buffer.readu8(ImageBuffer, SampleIndex + 3)
+
+			if BlendingMode == 0 then
+				if A > 0 then
+					buffer.writeu8(InternalBuffer, DrawIndex, buffer.readu8(ImageBuffer, SampleIndex))
+					buffer.writeu8(InternalBuffer, DrawIndex + 1, buffer.readu8(ImageBuffer, SampleIndex + 1))
+					buffer.writeu8(InternalBuffer, DrawIndex + 2, buffer.readu8(ImageBuffer, SampleIndex + 2))
+				end
+			elseif BlendingMode == 2 then
+				if A > 0 then
+					buffer.writeu8(InternalBuffer, DrawIndex, buffer.readu8(ImageBuffer, SampleIndex))
+					buffer.writeu8(InternalBuffer, DrawIndex + 1, buffer.readu8(ImageBuffer, SampleIndex + 1))
+					buffer.writeu8(InternalBuffer, DrawIndex + 2, buffer.readu8(ImageBuffer, SampleIndex + 2))
+					buffer.writeu8(InternalBuffer, DrawIndex + 3, 255)
+				end
+			elseif BlendingMode == 1 then
+				buffer.writeu32(InternalBuffer, DrawIndex, buffer.readu32(ImageBuffer, SampleIndex))
+			end
+
+			TexU += du
+			TexV += dv
+		end
+	end
+end
+
 --== MODULE FUCNTIONS ==--
 
 -- Canvas functions
@@ -624,37 +788,58 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 
 	local function DrawScanline(StartX, EndX, Y, ColR, ColG, ColB, Alpha, ColU32)
 		local BlendingMode = Canvas.AlphaBlendingMode
+		local CurResX, CurResY = Canvas.CurrentResX, Canvas.CurrentResY
 
 		if BlendingMode == 0 and Alpha > 0 then
 			if Alpha > 1 then Alpha = 1 end
 
-			-- Normal blending
-			StartX = math.clamp(StartX, 1, ResX)
-			EndX = math.clamp(EndX, 1, ResX)
-			Y = math.clamp(Y, 1, ResY)
+			StartX = math.clamp(StartX, 1, CurResX)
+			EndX = math.clamp(EndX, 1, CurResX)
+			Y = math.clamp(Y, 1, CurResY)
+
+			-- Y doesnt change per scanline so hoist it, raw bytes beats /255 round trip
+			local PixelBuf = Canvas.Buffer
+			local RowBase = (Y - 1) * CurResX * 4
+			local ColR255 = ColR * 255
+			local ColG255 = ColG * 255
+			local ColB255 = ColB * 255
 
 			for X = StartX, EndX do
-				local BgR, BgG, BgB = CanvasGetRGB(Canvas, X, Y)
-				local R = Lerp(BgR, ColR, Alpha)
-				local G = Lerp(BgG, ColG, Alpha)
-				local B = Lerp(BgB, ColB, Alpha)
-
-				CanvasSetRGB(Canvas, X, Y, R, G, B)
+				local Idx = RowBase + (X - 1) * 4
+				local BgR = buffer.readu8(PixelBuf, Idx)
+				local BgG = buffer.readu8(PixelBuf, Idx + 1)
+				local BgB = buffer.readu8(PixelBuf, Idx + 2)
+				buffer.writeu8(PixelBuf, Idx,     BgR + (ColR255 - BgR) * Alpha)
+				buffer.writeu8(PixelBuf, Idx + 1, BgG + (ColG255 - BgG) * Alpha)
+				buffer.writeu8(PixelBuf, Idx + 2, BgB + (ColB255 - BgB) * Alpha)
 			end
 		elseif BlendingMode == 2 and Alpha < 1 then
-			-- Add blending
+			-- add blending
 			if Alpha > 1 then Alpha = 1 end
 
-			StartX = math.clamp(StartX, 1, ResX)
-			EndX = math.clamp(EndX, 1, ResX)
-			Y = math.clamp(Y, 1, ResY)
+			StartX = math.clamp(StartX, 1, CurResX)
+			EndX = math.clamp(EndX, 1, CurResX)
+			Y = math.clamp(Y, 1, CurResY)
+
+			local PixelBuf = Canvas.Buffer
+			local RowBase = (Y - 1) * CurResX * 4
+			local ColR255 = ColR * 255
+			local ColG255 = ColG * 255
+			local ColB255 = ColB * 255
+			local Alpha255 = Alpha * 255
 
 			for X = StartX, EndX do
-				local BgA = CanvasGetAlpha(Canvas, X, Y)
-				CanvasSetRGBA(Canvas, X, Y, ColR, ColG, ColB, math.min(Alpha + BgA, 1))
+				local Idx = RowBase + (X - 1) * 4
+				local BgA = buffer.readu8(PixelBuf, Idx + 3)
+				local NewA = BgA + Alpha255
+				if NewA > 255 then NewA = 255 end
+				buffer.writeu8(PixelBuf, Idx,     ColR255)
+				buffer.writeu8(PixelBuf, Idx + 1, ColG255)
+				buffer.writeu8(PixelBuf, Idx + 2, ColB255)
+				buffer.writeu8(PixelBuf, Idx + 3, NewA)
 			end
 		elseif BlendingMode == 1 or Alpha >= 1 then
-			-- Replace/default mode
+			-- replace/default mode
 			InternalCanvas:SetBufferLine(ColU32, StartX, EndX, Y)
 		end
 	end
@@ -1564,13 +1749,12 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 
 		local GetImgU32 = ImageData.GetU32
 		local GetImgRGBA = ImageData.GetRGBA
+		local ImageBuffer = ImageData.ImageBuffer
 
 		local InternalBuffer = InternalCanvas.Buffer
 
 		if (BlendingMode == 1 or not TransparencyBlending) and ScaleX == 1 and ScaleY == 1 then
 			-- Draw normal image with no blending and no scale adjustments (most optimal)
-			local ImageBuffer = ImageData.ImageBuffer
-
 			local ImageWidth, ImageHeight = ImageData.Width, ImageData.Height
 			local ScaledWidth = math.ceil(ImageWidth * ScaleX)
 
@@ -1648,21 +1832,32 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 					local PlacementY = Y + ImgY - 1
 
 					if BlendingMode == 0 and TransparencyBlending then -- Normal blending
-						local ImgR, ImgG, ImgB, ImgA = GetImgRGBA(ImageData, SampleX, SampleY)
+						local ImgIndex = (SampleX + (SampleY - 1) * ImageResolutionX) * 4 - 4
+						local ImgA = buffer.readu8(ImageBuffer, ImgIndex + 3)
 
 						if ImgA == 0 then -- No need to do any calculations for completely transparent pixels
 							continue
 						end
 
-						if ImgA < 1 then
-							local BgR, BgG, BgB = CanvasGetRGB(Canvas, PlacementX, PlacementY)
+						local DrawIndex = (PlacementX + (PlacementY - 1) * ResX) * 4 - 4
+						local ImgR = buffer.readu8(ImageBuffer, ImgIndex)
+						local ImgG = buffer.readu8(ImageBuffer, ImgIndex + 1)
+						local ImgB = buffer.readu8(ImageBuffer, ImgIndex + 2)
 
-							ImgR = Lerp(BgR, ImgR, ImgA)
-							ImgG = Lerp(BgG, ImgG, ImgA)
-							ImgB = Lerp(BgB, ImgB, ImgA)
+						if ImgA < 255 then
+							local BgR = buffer.readu8(InternalBuffer, DrawIndex)
+							local BgG = buffer.readu8(InternalBuffer, DrawIndex + 1)
+							local BgB = buffer.readu8(InternalBuffer, DrawIndex + 2)
+							local InvA = 255 - ImgA
+
+							ImgR = FloorN((BgR * InvA + ImgR * ImgA) / 255)
+							ImgG = FloorN((BgG * InvA + ImgG * ImgA) / 255)
+							ImgB = FloorN((BgB * InvA + ImgB * ImgA) / 255)
 						end
 
-						CanvasSetRGB(Canvas, PlacementX, PlacementY, ImgR, ImgG, ImgB)
+						buffer.writeu8(InternalBuffer, DrawIndex, ImgR)
+						buffer.writeu8(InternalBuffer, DrawIndex + 1, ImgG)
+						buffer.writeu8(InternalBuffer, DrawIndex + 2, ImgB)
 					elseif BlendingMode == 2 and TransparencyBlending then
 						local ImgR, ImgG, ImgB, ImgA = GetImgRGBA(ImageData, SampleX, SampleY)
 						local BgA = CanvasGetAlpha(Canvas, PlacementX, PlacementY)
@@ -2114,81 +2309,14 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 		local YMin = math.max(1, Y1)
 		local YMax = math.min(self.CurrentResY, Y3)
 
-		local function Plotline(ax, bx, Y)
-			if ax > bx then
-				ax, bx = bx, ax
-			end
-
-			-- Pre-clipped scanline bounds
-			local StartX = math.max(1, ax)
-			local EndX = math.min(self.CurrentResX, bx)
-
-			DrawScanline(StartX, EndX, Y, ColR, ColG, ColB, Alpha, ColourU32)
-		end
-
 		local OrigX3, OrigX2, OrigX1 = X3, X2, X1
 		local OrigY1, OrigY3 = Y1, Y3
-
-		local function FillTopTriangle(X1, Y1, X2, Y2, X3, Y3)
-			local invslope1 = (X2 - X1) / (Y2 - Y1)
-			local invslope2 = (X3 - X1) / (Y3 - Y1)
-
-			local startY = math.max(Y1, YMin)
-			local endY = math.min(Y2 - 1, YMax)
-
-			local curx1 = X1 + invslope1 * (startY - Y1)
-			local curx2 = X1 + invslope2 * (startY - Y1)
-
-			for scanlineY = startY, endY do
-				local ax = RoundN(curx1)
-				local bx = RoundN(curx2)
-				Plotline(ax, bx, scanlineY)
-				curx1 += invslope1
-				curx2 += invslope2
-			end
-		end
-
-		local function FillBottomTriangle(X1, Y1, X2, Y2, X3, Y3)
-			local invslope1 = (X3 - X1) / (Y3 - Y1)
-			local invslope2 = (X3 - X2) / (Y3 - Y2)
-
-			-- Start and end scanlines adjusted for clipping
-			local startY = math.max(Y2, YMin)
-			local endY = math.min(Y3, YMax)
-
-			-- Adjust starting X positions based on clipping
-			local curx1 = X1 + invslope1 * (startY - Y1)
-			local curx2 = X2 + invslope2 * (startY - Y2)
-
-			-- Handle edge cases for infinite or NaN slopes
-			if invslope1 >= math.huge or invslope1 ~= invslope1 then
-				invslope1 = 0
-				invslope2 = 0
-
-				-- Adjust starting X values if slopes are invalid
-				if OrigY1 == OrigY3 then
-					curx1 = OrigX1
-				else
-					curx1 = OrigX2
-				end
-				curx2 = OrigX3
-			end
-
-			-- Rasterize the bottom triangle
-			for scanlineY = startY, endY do
-				local ax = RoundN(curx1)
-				local bx = RoundN(curx2)
-				Plotline(ax, bx, scanlineY)
-				curx1 += invslope1
-				curx2 += invslope2
-			end
-		end
 
 		-- Fill triangle
 		local X4 = X1 + (Y2 - Y1) / (Y3 - Y1) * (X3 - X1)
 
-		FillTopTriangle(X1, Y1, X2, Y2, X4, Y2)
-		FillBottomTriangle(X2, Y2, X4, Y2, X3, Y3)
+		FillTopTriangleModule(X1, Y1, X2, Y2, X4, Y2, YMin, YMax, self.CurrentResX, DrawScanline, ColR, ColG, ColB, Alpha, ColourU32)
+		FillBottomTriangleModule(X2, Y2, X4, Y2, X3, Y3, YMin, YMax, OrigX1, OrigX2, OrigX3, OrigY1, OrigY3, self.CurrentResX, DrawScanline, ColR, ColG, ColB, Alpha, ColourU32)
 	end
 
 
@@ -2248,8 +2376,6 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 		local dv2 = V3 - V1
 		local du2 = U3 - U1
 
-		local TexU, TexV = 0, 0
-
 		local dax_step, dbx_step = 0, 0
 		local du1_step, dv1_step = 0, 0
 		local du2_step, dv2_step = 0, 0
@@ -2263,107 +2389,8 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 		du2_step = du2 / math.abs(dy2)
 		dv2_step = dv2 / math.abs(dy2)
 
-		local ImgGetRGBA = ImageData.GetRGBA
-		local ImgGetU32 = ImageData.GetU32
-
-		local function Plotline(ax, bx, tex_su, tex_eu, tex_sv, tex_ev, Y, IsBot)
-			if ax > bx then
-				ax, bx = Swap(ax, bx)
-				tex_su, tex_eu = Swap(tex_su, tex_eu)
-				tex_sv, tex_ev = Swap(tex_sv, tex_ev)
-			end
-
-			local ScanlineLength = bx - ax
-			if ScanlineLength == 0 then return end -- Avoid divide-by-zero
-
-			-- Calculate UV increments per pixel
-			local Step = 1 / ScanlineLength
-			local du = (tex_eu - tex_su) * Step
-			local dv = (tex_ev - tex_sv) * Step
-
-			-- Clip X right
-			if bx > self.CurrentResX then
-				ScanlineLength = self.CurrentResX - ax
-			end
-
-			-- Clip X left
-			local StartOffsetX = 0
-			local t = 0
-
-			if ax < 1 then	
-				StartOffsetX = -(ax - 1)
-				t = Step * StartOffsetX
-			end
-
-			-- Initialize UV coordinates with offset
-			TexU = tex_su + t * (tex_eu - tex_su)
-			TexV = tex_sv + t * (tex_ev - tex_sv)
-
-			TexU = TexU * TexResX + 1
-			TexV = TexV * TexResY + 1
-
-			du *= TexResX
-			dv *= TexResY
-
-			-- Main loop to draw pixels across the scanline
-
-			if Brightness < 1 then
-				-- Adjust brightness loop
-				for j = StartOffsetX, ScanlineLength do
-					local SampleX = ClampN(FloorN(TexU), 1, TexResX)
-					local SampleY = ClampN(FloorN(TexV), 1, TexResY)
-
-					local DrawX = ax + j
-
-					local R, G, B, A = ImgGetRGBA(ImageData, SampleX, SampleY)
-					R *= Brightness
-					G *= Brightness
-					B *= Brightness
-
-					if BlendingMode == 0 and A > 0 then -- Normal
-						CanvasSetRGB(InternalCanvas, DrawX, Y, R, G, B)
-					elseif BlendingMode == 2 and A > 0 then -- Add blending
-						CanvasSetRGBA(InternalCanvas, DrawX, Y, R, G, B, 1)
-					elseif BlendingMode == 1 then
-						CanvasSetRGBA(InternalCanvas, DrawX, Y, R, G, B, A)
-					end
-
-					-- Increment UV values
-					TexU += du
-					TexV += dv
-				end
-			else
-				-- Normal render loop
-				for j = StartOffsetX, ScanlineLength do
-					local SampleX = ClampN(FloorN(TexU), 1, TexResX)
-					local SampleY = ClampN(FloorN(TexV), 1, TexResY)
-
-					local DrawX = ax + j
-
-					if BlendingMode == 0 then -- Normal
-						local R, G, B, A = ImgGetRGBA(ImageData, SampleX, SampleY)
-
-						if A > 0 then
-							CanvasSetRGB(InternalCanvas, DrawX, Y, R, G, B)
-						end
-					elseif BlendingMode == 2 then -- Add blending
-						local R, G, B, A = ImgGetRGBA(ImageData, SampleX, SampleY)
-
-						if A > 0 then
-							CanvasSetRGBA(InternalCanvas, DrawX, Y, R, G, B, 1)
-						end
-					elseif BlendingMode == 1 then -- Replace
-						CanvasSetU32(InternalCanvas, DrawX, Y, ImgGetU32(ImageData, SampleX, SampleY))
-					end
-
-					-- Increment UV values
-					TexU += du
-					TexV += dv
-				end
-			end
-
-
-		end
+		local ImageBuffer = ImageData.ImageBuffer
+		local InternalBuffer = InternalCanvas.Buffer
 
 		-- Clip Y top
 		local YStart = 1
@@ -2390,7 +2417,7 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 			local tex_ev = V1 + i * dv2_step
 
 			-- Scan line
-			Plotline(ax, bx, tex_su, tex_eu, tex_sv, tex_ev, Y1 + i)
+			DrawTexturedTrianglePlotlineModule(ax, bx, tex_su, tex_eu, tex_sv, tex_ev, Y1 + i, self.CurrentResX, TexResX, TexResY, Brightness, BlendingMode, ImageBuffer, InternalBuffer)
 		end
 
 		dy1 = Y3 - Y2
@@ -2431,7 +2458,7 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 			local tex_eu = U1 + (i - Y1) * du2_step
 			local tex_ev = V1 + (i - Y1) * dv2_step
 
-			Plotline(ax, bx, tex_su, tex_eu, tex_sv, tex_ev, i, true)
+			DrawTexturedTrianglePlotlineModule(ax, bx, tex_su, tex_eu, tex_sv, tex_ev, i, self.CurrentResX, TexResX, TexResY, Brightness, BlendingMode, ImageBuffer, InternalBuffer)
 		end
 	end
 
@@ -2618,59 +2645,59 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 		StartX = math.max(1, StartX)
 		StartY = math.max(1, StartY)
 
-		local SampleX = SampleXStart
-
 		local BlendingMode = Canvas.AlphaBlendingMode
 
-		-- Main draw loop
-		for DrawX = StartX, EndX do
+		-- pick rounding fn once instead of branching every pixel
+		local RoundX = FlipX and CeilN or FloorN
+		local RoundY = FlipY and CeilN or FloorN
+
+		-- y outer x inner so the inner loop hits sequential memory, blending branch stays outside
+		if BlendingMode == 0 then -- normal
 			local SampleY = SampleYStart
-			local RoundSampleX
-
-			if FlipX then
-				RoundSampleX = CeilN(SampleX)
-			else
-				RoundSampleX = FloorN(SampleX)
-			end
-
 			for DrawY = StartY, EndY do
-				local RoundSampleY
+				local RoundSampleY = RoundY(SampleY)
+				local SampleX = SampleXStart
+				for DrawX = StartX, EndX do
+					local R, G, B, A = ImgGetRGBA(ImageData, RoundX(SampleX), RoundSampleY)
 
-				if FlipY then
-					RoundSampleY = CeilN(SampleY)
-				else
-					RoundSampleY = FloorN(SampleY)
-				end
-
-				if BlendingMode == 0 then -- Normal
-					local R, G, B, A = ImgGetRGBA(ImageData, RoundSampleX, RoundSampleY)
-
-					if A == 0 then -- No need to do any calculations for completely transparent pixels
-						SampleY += SampleYStep
-						continue
+					if A ~= 0 then
+						if A < 1 then
+							local BgR, BgG, BgB = CanvasGetRGB(InternalCanvas, DrawX, DrawY)
+							R = Lerp(BgR, R, A)
+							G = Lerp(BgG, G, A)
+							B = Lerp(BgB, B, A)
+						end
+						CanvasSetRGB(InternalCanvas, DrawX, DrawY, R, G, B)
 					end
 
-					if A < 1 then
-						local BgR, BgG, BgB = CanvasGetRGB(InternalCanvas, DrawX, DrawY)
-
-						R = Lerp(BgR, R, A)
-						G = Lerp(BgG, G, A)
-						B = Lerp(BgB, B, A)
-					end
-
-					CanvasSetRGB(InternalCanvas, DrawX, DrawY, R, G, B)
-				elseif BlendingMode == 2 then -- Add
-					local R, G, B, A = ImgGetRGBA(ImageData, SampleX, SampleY)
-					local BgA = CanvasGetAlpha(Canvas, DrawX, DrawY)
-					CanvasSetRGBA(Canvas, DrawX, DrawY, R, G, B, math.min(BgA + A, 1))
-				elseif BlendingMode == 1 then -- Replace
-					CanvasSetU32(InternalCanvas, DrawX, DrawY, ImgGetU32(ImageData, RoundSampleX, RoundSampleY))
+					SampleX += SampleXStep
 				end
-
 				SampleY += SampleYStep
 			end
-
-			SampleX += SampleXStep
+		elseif BlendingMode == 1 then -- replace
+			local SampleY = SampleYStart
+			for DrawY = StartY, EndY do
+				local RoundSampleY = RoundY(SampleY)
+				local SampleX = SampleXStart
+				for DrawX = StartX, EndX do
+					CanvasSetU32(InternalCanvas, DrawX, DrawY, ImgGetU32(ImageData, RoundX(SampleX), RoundSampleY))
+					SampleX += SampleXStep
+				end
+				SampleY += SampleYStep
+			end
+		elseif BlendingMode == 2 then -- add (note: original passed raw unrounded coords here, this fixes that)
+			local SampleY = SampleYStart
+			for DrawY = StartY, EndY do
+				local RoundSampleY = RoundY(SampleY)
+				local SampleX = SampleXStart
+				for DrawX = StartX, EndX do
+					local R, G, B, A = ImgGetRGBA(ImageData, RoundX(SampleX), RoundSampleY)
+					local BgA = CanvasGetAlpha(Canvas, DrawX, DrawY)
+					CanvasSetRGBA(Canvas, DrawX, DrawY, R, G, B, math.min(BgA + A, 1))
+					SampleX += SampleXStep
+				end
+				SampleY += SampleYStep
+			end
 		end
 	end
 
@@ -2843,6 +2870,9 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 
 	end
 
+	local ScaledXCache = {}
+	local ScaledYCache = {}
+
 	--[[
 		Draws text to the canvas with bitmap font rendering.
 		
@@ -2900,6 +2930,26 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 
 		local CanvasResX, CanvasResY = self.CurrentResX, self.CurrentResY
 
+		-- cache per char size + scale so repeated calls with the same font dont alloc every frame
+		local xKey = CharWidth .. "_" .. Scale
+		local ScaledX = ScaledXCache[xKey]
+		if not ScaledX then
+			ScaledX = table.create(CharWidth)
+			for sx = 1, CharWidth do
+				ScaledX[sx] = CeilN(sx / Scale)
+			end
+			ScaledXCache[xKey] = ScaledX
+		end
+		local yKey = CharHeight .. "_" .. Scale
+		local ScaledY = ScaledYCache[yKey]
+		if not ScaledY then
+			ScaledY = table.create(CharHeight)
+			for sy = 1, CharHeight do
+				ScaledY[sy] = CeilN(sy / Scale)
+			end
+			ScaledYCache[yKey] = ScaledY
+		end
+
 		local TextLines = string.split(Text, "\n")
 
 		for i, TextLine in pairs(TextLines) do
@@ -2951,9 +3001,7 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 							break
 						end
 
-						SampleY = CeilN(SampleY / Scale)
-
-						local Row: number = TextCharacter[SampleY]
+						local Row: number = TextCharacter[ScaledY[SampleY]]
 
 						for SampleX = StartOffsetX, CharWidth do
 							local PlacementX = X + SampleX - 1 + OffsetX
@@ -2962,9 +3010,7 @@ function CanvasDraw.new(Parent: ParentType?, Resolution: Vector2?, CanvasColour:
 								continue
 							end
 
-							SampleX = CeilN(SampleX / Scale)
-
-							if bit32band(bit32rshift(Row, OrigCharWidth - SampleX), 1) == 1 then
+							if bit32band(bit32rshift(Row, OrigCharWidth - ScaledX[SampleX]), 1) == 1 then
 								if BlendingMode == 0 then -- Normal
 									CanvasSetRGB(InternalCanvas, PlacementX, PlacementY, ColR, ColG, ColB)
 								elseif BlendingMode == 1 or BlendingMode == 2 then -- Replace and add


### PR DESCRIPTION
Stacked on #8, this PR speeds up DrawFastImageRectXY, replace-mode DrawImageRectXY, and thin DrawLineXY by using tighter direct buffer paths and less per-call overhead without changing behavior, and the my compat run passed 440/440.

Depends on #8.